### PR TITLE
allow-admin-to-create-slime-on-backend

### DIFF
--- a/server/api/slimes.js
+++ b/server/api/slimes.js
@@ -2,6 +2,23 @@ const router = require('express').Router()
 const {Slime} = require('../db/models')
 module.exports = router
 
+router.post('/:userId', async (req, res, next) => {
+  try {
+    if (req.user.admin) {
+      const newSlime = await Slime.create(req.body)
+      if (newSlime) {
+        res.status(201).json(newSlime)
+      } else {
+        res.status(404).send('Could Not Create Slime')
+      }
+    } else {
+      res.status(401).send('Not An Admin!')
+    }
+  } catch (error) {
+    next(error)
+  }
+})
+
 router.get('/:id', async (req, res, next) => {
   try {
     const slime = await Slime.findByPk(req.params.id)

--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -26,6 +26,10 @@ const User = db.define('user', {
   },
   googleId: {
     type: Sequelize.STRING
+  },
+  admin: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
   }
 })
 


### PR DESCRIPTION
### Assignee Tasks

- Added Admin to Model
- Added POST route on backend to allow only admins to create new slime


